### PR TITLE
Tweaks used to make mpaste run as non root and allow packaging into an RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+release
+version

--- a/build_rpm
+++ b/build_rpm
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+ARG0=${0##*/}
+NAME=mpaste
+declare -a MOCK_ROOT
+
+usage() {
+  cat << __END
+
+  Gather help files into source tarballs for packaging
+
+  usage: $ARG0 --root CONFIG --version VER \\
+    --release REL [--hash HASH] \\
+    [--verbose]
+
+  Options:
+
+  --version    Version of RPM to be built.
+
+  --release    Release of RPM to be built.
+
+  --root       Chroot config to use when building the RPM.
+               Can be specified more than once.
+
+  --hash       Short hash from Git revision RPM will be built from.
+
+__END
+
+  exit $1
+
+}
+
+abort() {
+  echo "$*" >&2
+  exit 1
+}
+
+LongOpts="hash:,version:,release:,root:,help"
+parsed_options=$(getopt -o "" --long "$LongOpts" -- "$@")
+
+if [ $? != 0 ]
+then
+  usage
+fi
+eval set -- "${parsed_options}"
+
+while [ "$1" != '--' ]
+do
+  case "$1" in
+    --hash)      HASH=$2;           shift 2 ;;
+    --version)   VERSION=$2;        shift 2 ;;
+    --release)   RELEASE=$2;        shift 2 ;;
+    --root)      MOCK_ROOT+=($2);   shift 2 ;;
+    --help)      usage 0;           shift   ;;
+    *) echo "Illegal option $1" >&2
+       usage ;;
+  esac
+done
+
+if [ -z "${MOCK_ROOT[@]}" ]; then
+  echo "Must supply --root" >&2
+  exit 1
+fi
+
+[ -z "$HASH" ] && HASH="$(git rev-parse --short HEAD 2>/dev/null)"
+
+if [ -z "$RELEASE" ]; then
+  RELEASE=$(( $(cat release) + 1 ))
+  echo $RELEASE > release
+fi
+
+if [ -z "$VERSION" ]; then
+  VERSION=$(cat version)
+elif [[ "$VERSION" != $(cat version) ]]; then
+  RELEASE=1
+  echo $RELEASE > release
+  echo $VERSION > version
+fi
+
+TARBALL=~/rpmbuild/SOURCES/${NAME}-${VERSION}-${HASH}.tar.gz
+SPEC=${NAME}.spec
+
+echo Building $NAME source version $VERSION from Git revision ${HASH} >&2
+
+(
+  /bin/rm ${TARBALL} 2>/dev/null
+  tar  \
+    -hczvf ${TARBALL} \
+    --transform="s,^,${NAME}-${VERSION}/," \
+    etc/ \
+    LICENSE \
+    mpasted \
+    mpaste.conf \
+    public \
+    tools
+) >&2
+
+tar -tf ${TARBALL} >&2
+cp ${SPEC} ~/rpmbuild/SPECS
+SPEC=~/rpmbuild/SPECS/${SPEC}
+
+sed -i s/^%define\ RELEASE.*/%define\ RELEASE\ ${RELEASE}/ ${SPEC}
+sed -i s/^%define\ VERSION.*/%define\ VERSION\ ${VERSION}/ ${SPEC}
+sed -i s/^%define\ HASH.*/%define\ HASH\ ${HASH}/ ${SPEC}
+
+MOCK_DIR=/var/lib/mock/
+for root in ${MOCK_ROOT[@]}; do
+  mock --buildsrpm --root ${root} \
+    --spec ${SPEC} --sources ~/rpmbuild/SOURCES/ \
+    || exit 1
+
+  mock --no-clean --root ${root} \
+    --rebuild \
+    ${MOCK_DIR}/${root}/result/${NAME}-${VERSION}-${RELEASE}.${HASH}.*.src.rpm \
+    || abort "Unable to build RPM"
+
+done
+
+for root in ${MOCK_ROOT[@]}; do
+  ls ${MOCK_DIR}/${root}/result/*.rpm
+done
+
+exit 0

--- a/etc/mpaste.service
+++ b/etc/mpaste.service
@@ -1,14 +1,20 @@
 [Unit]
 Description=mPaste - a lean, mean pastebinnin' machine.
 Requires=network.target
-Requires=nginx.service
 After=network.target
 # put here other service requirements
 
 [Service]
+Type=simple
+EnvironmentFile=/etc/sysconfig/mpaste
+User=mpaste
 SyslogIdentifier=mpaste
-PIDFile=/var/run/mpaste.pid
-ExecStart=/usr/bin/hypnotoad -f /usr/local/mpaste/mpasted
+RuntimeDirectory=mpaste
+PIDFile=/var/run/mpaste/mpaste.pid
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir -p /var/lock/subsys/mpaste
+ExecStartPre=/usr/bin/chown mpaste /var/lock/subsys/mpaste
+ExecStart=/usr/bin/hypnotoad -f /usr/share/mpaste/mpasted
 Restart=on-failure
 
 [Install]

--- a/etc/profile.sh
+++ b/etc/profile.sh
@@ -1,0 +1,1 @@
+export MPASTE_HOST=paste.kororaproject.org

--- a/mpaste.conf
+++ b/mpaste.conf
@@ -1,0 +1,29 @@
+# mpaste service environment files
+# installed to /etc/sysconfig/mpaste
+
+# Set lockfile location
+MPASTE_LOCK_FILE=/var/lock/subsys/mpaste/mpaste.lock
+
+# Set pid file location
+MPASTE_PID_FILE=/var/run/mpaste/mpaste.pid
+
+# Set listen location for use with mojolicious hypnotoad. Multiple values can be delimited with a , or space.
+MPASTE_HYPNOTOAD_LISTEN=http://*:8000 
+
+# Set how long in seconds, a paste will stick around for.
+MPASTE_HOLD_TIME=604800
+
+# Set to hide paste history.
+MPASTE_NO_HISTORY=0
+
+# Set the directory where pastes and db are stored.
+MPASTE_PASTE_DIR=/var/lib/mpaste/
+
+# Set the frequency, in seconds, to check for expired pastes.
+MPASTE_REAP_TIME=300
+
+# Set the secret passphrases used for signed cookies.
+MPASTE_SECRETS=change_to_a_secret
+
+# Set the maximum upload limit in bytes.
+MPASTE_UPLOAD_LIMIT=10485760

--- a/mpaste.spec
+++ b/mpaste.spec
@@ -1,0 +1,73 @@
+%define VERSION 0.1
+%define RELEASE 1
+%define HASH 1a23b45
+
+Name:		mpaste
+Version:	%{VERSION}
+Release:	%{RELEASE}.%{HASH}%{dist}
+Summary:	Lean, mean and clean, pastebinnin' machine.
+
+Group:		Utilities/Misc
+License:	AGPL
+URL:		https://github.com/firnsy/mpaste
+Source0:	%{name}-%{version}-%{HASH}.tar.gz
+
+BuildArch:	noarch
+Requires:	perl-Mojolicious
+Requires:	perl-DBD-SQLite
+
+%description
+Lean, mean and clean, pastebinnin' machine.
+
+%prep
+%setup -q
+
+%build
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/usr/share/%{name} %{buildroot}/usr/bin
+mkdir -p %{buildroot}/usr/lib/systemd/system
+mkdir -p %{buildroot}/etc/sysconfig
+mkdir -p %{buildroot}/etc/profile.d
+cp -a %{_builddir}/%{name}-%{version}/{public,mpasted,LICENSE} %{buildroot}/usr/share/%{name}
+cp -a %{_builddir}/%{name}-%{version}/tools/%{name} %{buildroot}/usr/bin
+cp -a %{_builddir}/%{name}-%{version}/etc/%{name}.service %{buildroot}/usr/lib/systemd/system
+cp -a %{_builddir}/%{name}-%{version}/etc/profile.sh %{buildroot}/etc/profile.d/%{name}.sh
+cp -a %{_builddir}/%{name}-%{version}/mpaste.conf %{buildroot}/etc/sysconfig/%{name}
+
+%pre
+id %{name} &>/dev/null || {
+  useradd --home-dir /var/lib/mpaste \
+    --create-home --system %{name} \
+    --shell /sbin/nologin
+
+  # permissions do not appear to be set correctly by useradd 
+  # when invoked during RPM install. The following 
+  # corrects that with the subtlety of Mjolnir
+  chown mpaste.mpaste /var/lib/mpaste
+  chmod 755 /var/lib/mpaste
+}
+
+%post
+systemctl daemon-reload &>/dev/null
+
+%files
+%defattr(-,root,root,-)
+%attr(755,root,root) /usr/share/%{name}/mpasted
+%attr(644,root,root) /usr/share/%{name}/LICENSE
+/usr/share/%{name}/public/*
+%config(noreplace) %attr(644,root,root) /etc/sysconfig/%{name}
+%attr(644,root,root) /usr/lib/systemd/system/%{name}.service
+
+%package cli
+Version:	%{VERSION}
+Summary:	Command line mpaste client
+Group:		Utilities/Misc
+Requires:	curl
+%description cli
+Command line client for posting data to an mpaste server
+
+%files cli
+%attr(755,root,root) /usr/bin/%{name}
+%attr(644,root,root) /etc/profile.d/%{name}.sh
+
+%changelog

--- a/mpasted
+++ b/mpasted
@@ -41,6 +41,8 @@ use constant SECRETS          => [split(/, /, $ENV{MPASTE_SECRETS} // 'mpaste')]
 use constant UPLOAD_LIMIT     => $ENV{MPASTE_UPLOAD_LIMIT} // 10485760;      # defaults to 10MB
 use constant VERSION          => '2.2';
 
+use constant LOCK_FILE     => $ENV{MPASTE_LOCK_FILE} // '/var/lock/subsys/mpaste.lock';
+use constant PID_FILE     => $ENV{MPASTE_PID_FILE} // '/var/run/mpaste.pid';
 #
 # PRIVATE FUNCTIONS
 
@@ -281,8 +283,8 @@ _build_db;
 # production configuration
 app->config(hypnotoad => {
   listen    => HYPNOTOAD_LISTEN,
-  lock_file => '/var/lock/subsys/mpaste.lock',
-  pid_file  => '/var/run/mpaste.pid'
+  lock_file => LOCK_FILE,
+  pid_file  => PID_FILE
 });
 
 # create store path as requried


### PR DESCRIPTION
added: script to build RPM using mock
added: mapste spec file that produces mpaste and mpaste-cli RPMs
removed: mpaste service dependence on nginx, allows use of Apache or Nginx
added: directives to mpaste.service to setup environment correctly for running as mpaste user
added: allow environment to override lock and pid file paths
added: default EnvironmentFile - MPASTE_SECRETS needs to be updated after install
added: profile script to set MPASTE_HOST=paste.kororaproject.org 
